### PR TITLE
Install bzip2 into image

### DIFF
--- a/2.1/sdk/Dockerfile
+++ b/2.1/sdk/Dockerfile
@@ -17,6 +17,10 @@ RUN wget "$NODE_DOWNLOAD_URL" -O nodejs.tar.gz \
     && npm i -g yarn@$YARN_VERSION \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
+# install bzip2
+RUN curl -O "http://ftp.us.debian.org/debian/pool/main/b/bzip2/bzip2_1.0.6-8.1_amd64.deb" \
+    && dpkg -i bzip2_1.0.6-8.1_amd64.deb
+
 # warmup NuGet package cache
 COPY packagescache.csproj /tmp/warmup/
 RUN dotnet restore /tmp/warmup/packagescache.csproj \

--- a/2.1/sdk/Dockerfile
+++ b/2.1/sdk/Dockerfile
@@ -19,7 +19,8 @@ RUN wget "$NODE_DOWNLOAD_URL" -O nodejs.tar.gz \
 
 # install bzip2
 RUN curl -O "http://ftp.us.debian.org/debian/pool/main/b/bzip2/bzip2_1.0.6-8.1_amd64.deb" \
-    && dpkg -i bzip2_1.0.6-8.1_amd64.deb
+    && dpkg -i bzip2_1.0.6-8.1_amd64.deb \
+    && rm bzip2_1.0.6-8.1_amd64.deb
 
 # warmup NuGet package cache
 COPY packagescache.csproj /tmp/warmup/


### PR DESCRIPTION
Address the following failure when executing `yarn install`.
```
EXEC : Phantom installation failed { error : Command failed: tar jxf /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 
  tar (child): bzip2: Cannot exec: No such file or directory
  tar (child): Error is not recoverable: exiting now
  tar: Child returned status 2
  tar: Error is not recoverable: exiting now
````